### PR TITLE
Allow `dead_code` in tests

### DIFF
--- a/tests/complex.rs
+++ b/tests/complex.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use edn_derive::{Deserialize, Serialize};
 use edn_rs::EdnError;
 

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use edn_derive::Deserialize;
 use edn_rs::EdnError;
 

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use edn_derive::Serialize;
 
 #[derive(Serialize)]

--- a/tests/unnamed_struct_deserialize.rs
+++ b/tests/unnamed_struct_deserialize.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use edn_derive::Deserialize;
 use edn_rs::EdnError;
 
@@ -18,10 +20,7 @@ fn main() -> Result<(), EdnError> {
 
     let person: Person = edn_rs::from_str(edn_person)?;
 
-    assert_eq!(
-        person,
-        Person("joana".to_string(), 290000, Kind::Pirate)
-    );
+    assert_eq!(person, Person("joana".to_string(), 290000, Kind::Pirate));
 
     Ok(())
 }

--- a/tests/unnamed_struct_serialize.rs
+++ b/tests/unnamed_struct_serialize.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use edn_derive::Serialize;
 
 #[derive(Serialize)]


### PR DESCRIPTION
Just less noise.