### PR TITLE
 no_std compatibility. Macros output core and alloc, not std.

### DIFF
--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -29,8 +29,8 @@ fn expand_named_struct(struct_name: &Ident, fields: &Punctuated<Field, Comma>) -
     let deserialized_fields = structs::named_field_deserialization(fields);
     quote! {
         impl edn_rs::Deserialize for #struct_name {
-            fn deserialize(edn: &edn_rs::Edn) -> std::result::Result<Self, edn_rs::EdnError> {
-                std::result::Result::Ok(Self {
+            fn deserialize(edn: &edn_rs::Edn) -> core::result::Result<Self, edn_rs::EdnError> {
+                core::result::Result::Ok(Self {
                     #deserialized_fields
                 })
             }
@@ -42,8 +42,8 @@ fn expand_unnamed_struct(struct_name: &Ident, fields: &Punctuated<Field, Comma>)
     let deserialized_fields = structs::unnamed_field_deserialization(fields);
     quote! {
         impl edn_rs::Deserialize for #struct_name {
-            fn deserialize(edn: &edn_rs::Edn) -> std::result::Result<Self, edn_rs::EdnError> {
-                std::result::Result::Ok(Self {
+            fn deserialize(edn: &edn_rs::Edn) -> core::result::Result<Self, edn_rs::EdnError> {
+                core::result::Result::Ok(Self {
                     #deserialized_fields
                 })
             }
@@ -54,10 +54,10 @@ fn expand_unnamed_struct(struct_name: &Ident, fields: &Punctuated<Field, Comma>)
 fn expand_unit_struct(struct_name: &Ident) -> TokenStream2 {
     quote! {
         impl edn_rs::Deserialize for #struct_name {
-            fn deserialize(edn: &edn_rs::Edn) -> std::result::Result<Self, edn_rs::EdnError> {
+            fn deserialize(edn: &edn_rs::Edn) -> core::result::Result<Self, edn_rs::EdnError> {
                 match edn {
-                    edn_rs::Edn::Nil => std::result::Result::Ok(Self),
-                    _ => std::result::Result::Err(edn_rs::EdnError::Deserialize(format!(
+                    edn_rs::Edn::Nil => core::result::Result::Ok(Self),
+                    _ => core::result::Result::Err(edn_rs::EdnError::Deserialize(alloc::format!(
                                 "couldn't convert {} into an unit struct",
                                 edn
                     )))
@@ -74,23 +74,23 @@ fn expand_enum(enum_name: &Ident, data_enum: &DataEnum) -> TokenStream2 {
 
     quote! {
         impl edn_rs::Deserialize for #enum_name {
-            fn deserialize(edn: &edn_rs::Edn) -> std::result::Result<Self, edn_rs::EdnError> {
+            fn deserialize(edn: &edn_rs::Edn) -> core::result::Result<Self, edn_rs::EdnError> {
                 match edn {
                     edn_rs::Edn::Key(k) => match &k[..] {
                         #deserialized_variants
-                        _ => std::result::Result::Err(edn_rs::EdnError::Deserialize(format!(
+                        _ => core::result::Result::Err(edn_rs::EdnError::Deserialize(alloc::format!(
                                 "couldn't convert {} keyword into enum",
                                 k
                         )))
                     },
                     edn_rs::Edn::Str(s) => match &s[..] {
                         #deserialized_variants
-                        _ => std::result::Result::Err(edn_rs::EdnError::Deserialize(format!(
+                        _ => core::result::Result::Err(edn_rs::EdnError::Deserialize(alloc::format!(
                                 "couldn't convert {} string into enum",
                                 s
                         ))),
                     },
-                    _ => std::result::Result::Err(edn_rs::EdnError::Deserialize(format!(
+                    _ => core::result::Result::Err(edn_rs::EdnError::Deserialize(alloc::format!(
                                 "couldn't convert {} into enum",
                                 edn
                     ))),

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -31,14 +31,14 @@ fn expand_named_struct(struct_name: &Ident, fields: &Punctuated<Field, Comma>) -
         let keyword = edn::field_to_keyword(&quote! {#name}.to_string());
 
         quote! {
-            format!("{} {}, ", #keyword, self.#name.serialize())
+            alloc::format!("{} {}, ", #keyword, self.#name.serialize())
         }
     });
 
     quote! {
         impl edn_rs::Serialize for #struct_name {
-            fn serialize(&self) -> std::string::String {
-                let mut s = std::string::String::new();
+            fn serialize(&self) -> alloc::string::String {
+                let mut s = alloc::string::String::new();
                 s.push_str("{ ");
                 #(s.push_str(&#it);)*
                 s.push_str("}");
@@ -52,14 +52,14 @@ fn expand_unnamed_struct(struct_name: &Ident, fields: &Punctuated<Field, Comma>)
     let it = fields.iter().enumerate().map(|(i, _)| {
         let i = syn::Index::from(i); // Eg: `0usize` to `0`
         quote! {
-            format!("{} {}, ", #i, self.#i.serialize())
+            alloc::format!("{} {}, ", #i, self.#i.serialize())
         }
     });
 
     quote! {
         impl edn_rs::Serialize for #struct_name {
-            fn serialize(&self) -> std::string::String {
-                let mut s = std::string::String::from("{ ");
+            fn serialize(&self) -> alloc::string::String {
+                let mut s = alloc::string::String::from("{ ");
                 #(s.push_str(&#it);)*
                 s.push_str("}");
                 s
@@ -71,8 +71,8 @@ fn expand_unnamed_struct(struct_name: &Ident, fields: &Punctuated<Field, Comma>)
 fn expand_unit_struct(struct_name: &Ident) -> TokenStream2 {
     quote! {
         impl edn_rs::Serialize for #struct_name {
-            fn serialize(&self) -> std::string::String {
-                String::from("nil")
+            fn serialize(&self) -> alloc::string::String {
+                alloc::string::String::from("nil")
             }
         }
     }
@@ -94,7 +94,7 @@ fn expand_enum(enum_name: &Ident, data_enum: &DataEnum) -> TokenStream2 {
 
     quote! {
         impl edn_rs::Serialize for #enum_name {
-            fn serialize(&self) -> std::string::String {
+            fn serialize(&self) -> alloc::string::String {
                 match self {
                     #(#it)*
                 }


### PR DESCRIPTION
https://github.com/edn-rs/pico-edn/blob/86df5d1155b0177af400fb54ceaab67407157d88/pico-edn/src/lib.rs#L28-L42
example here

I don't think there's an easy way to write tests for this, as test binaries require std. This crate itself still requires std, so building the crate doesn't actually do anything.

@evaporei any ideas/recommendations?